### PR TITLE
chore: correct release-level in repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/scheduler/docs",
   "client_documentation": "https://googleapis.dev/python/cloudscheduler/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5411429",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-scheduler",
   "distribution_name": "google-cloud-scheduler",


### PR DESCRIPTION
Latest release is 1.2.1.