### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "proto-plus >= 1.4.0",
+    "packaging >= 14.3"
 ]
 
 extras = {"libcst": "libcst >= 0.2.5"}

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "proto-plus >= 1.4.0",
-    "packaging >= 14.3"
+    "packaging >= 14.3",
 ]
 
 extras = {"libcst": "libcst >= 0.2.5"}

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -8,3 +8,4 @@
 google-api-core==1.22.2
 proto-plus==1.4.0
 libcst==0.2.5
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3