### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for Cloud Scheduler API
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-scheduler.svg
    :target: https://pypi.org/project/google-cloud-scheduler/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-scheduler.svg
@@ -90,4 +90,4 @@ Next Steps
    APIs that we cover.
 
 .. _Cloud Scheduler API Product documentation:  https://cloud.google.com/scheduler
-.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.