### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudscheduler",
     "name_pretty": "Google Cloud Scheduler",
     "product_documentation": "https://cloud.google.com/scheduler/docs",
-    "client_documentation": "https://googleapis.dev/python/cloudscheduler/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudscheduler/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5411429",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.