### PR TITLE
chore: assign googleapis/serverless-team as codeowner

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
     "api_id": "cloudscheduler.googleapis.com",
     "requires_billing": true,
     "default_version": "v1",
-    "codeowner_team": ""
+    "codeowner_team": "@googleapis/serverless-team"
 }


### PR DESCRIPTION
assign @googleapis/serverless-team as codeowner