### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudscheduler",
     "name_pretty": "Google Cloud Scheduler",
     "product_documentation": "https://cloud.google.com/scheduler/docs",
-    "client_documentation": "https://googleapis.dev/python/cloudscheduler/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudscheduler/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5411429",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Scheduler API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-scheduler.svg
    :target: https://pypi.org/project/google-cloud-scheduler/
 .. _Cloud Scheduler API: https://cloud.google.com/scheduler
-.. _Client Library Documentation: https://googleapis.dev/python/cloudscheduler/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudscheduler/latest
 .. _Product Documentation:  https://cloud.google.com/scheduler
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.