### PR TITLE
chore: update region tags to use correct product prefix

### DIFF
--- a/samples/snippets/app.yaml
+++ b/samples/snippets/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START cloud_scheduler_python_yaml]
+# [START cloudscheduler_python_yaml]
 runtime: python37
 service: my-service
-# [END cloud_scheduler_python_yaml]
+# [END cloudscheduler_python_yaml]

--- a/samples/snippets/create_job.py
+++ b/samples/snippets/create_job.py
@@ -15,7 +15,7 @@
 
 def create_scheduler_job(project_id, location_id, service_id):
     """Create a job with an App Engine target via the Cloud Scheduler API"""
-    # [START cloud_scheduler_create_job]
+    # [START cloudscheduler_create_job]
     from google.cloud import scheduler
 
     # Create a client.
@@ -45,13 +45,13 @@ def create_scheduler_job(project_id, location_id, service_id):
     response = client.create_job(request={"parent": parent, "job": job})
 
     print("Created job: {}".format(response.name))
-    # [END cloud_scheduler_create_job]
+    # [END cloudscheduler_create_job]
     return response
 
 
 def delete_scheduler_job(project_id, location_id, job_id):
     """Delete a job via the Cloud Scheduler API"""
-    # [START cloud_scheduler_delete_job]
+    # [START cloudscheduler_delete_job]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import scheduler
 
@@ -72,4 +72,4 @@ def delete_scheduler_job(project_id, location_id, job_id):
         print("Job deleted.")
     except GoogleAPICallError as e:
         print("Error: %s" % e)
-    # [END cloud_scheduler_delete_job]
+    # [END cloudscheduler_delete_job]

--- a/samples/snippets/main.py
+++ b/samples/snippets/main.py
@@ -14,7 +14,7 @@
 
 """App Engine app to serve as an endpoint for Cloud Scheduler samples."""
 
-# [START cloud_scheduler_app]
+# [START cloudscheduler_app]
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -29,7 +29,7 @@ def example_task_handler():
     return "Printed job payload: {}".format(payload)
 
 
-# [END cloud_scheduler_app]
+# [END cloudscheduler_app]
 
 
 @app.route("/")


### PR DESCRIPTION
Updating region tags from `cloud_scheduler_*` to `cloudscheduler_*` to match others. 
